### PR TITLE
Prevent WAIT_UNTIL_GUARDED from turning the player

### DIFF
--- a/js/custom-action-steps.js
+++ b/js/custom-action-steps.js
@@ -1,51 +1,41 @@
-ig.module("game.feature.combat.hex-combat-action-steps").requires("game.feature.combat.combat-action-steps").defines(function() {
-/*
-  //This was an attempt to make a version of WAIT_UNTIL_GUARDED that doesn't make the player follow the mouse.
-  //Edit: This does not work at all.
-  var r = Vec2.create(),
-    t = {
-      FACE_REVERSE: 1,
-      FACE: 2
-    };
-
-  ig.ACTION_STEP.WAIT_UNTIL_GUARDED_NO_FACE = ig.ActionStepBase.extend({
-    _wm: new ig.Config({
-      attributes: {
-        maxTime: {
-          _type: "Number",
-          _info: "Maximum time to wait"
+ig.module('game.feature.combat.hex-combat-action-steps')
+  .requires('game.feature.combat.combat-action-steps')
+  .defines(function () {
+    ig.ACTION_STEP.WAIT_UNTIL_GUARDED_NO_FACE = ig.ActionStepBase.extend({
+      _wm: new ig.Config({
+        attributes: {
+          maxTime: {
+            _type: 'Number',
+            _info: 'Maximum time to wait',
+          },
+          meleeOnly: {
+            _type: 'Boolean',
+            _info: 'Only continue when melee attack was guarded',
+          },
         },
-        meleeOnly: {
-          _type: "Boolean",
-          _info: "Only continue when melee attack was guarded"
+      }),
+      init: function (a) {
+        this.maxTime = a.maxTime;
+        this.meleeOnly = a.meleeOnly || false;
+      },
+      start: function (a) {
+        a.stepTimer = a.stepTimer + this.maxTime;
+      },
+      run: function (a) {
+        a = a.getCombatantRoot();
+        a.combo.guardTrapTime = a.combo.guardTrapTime + ig.system.tick;
+        if (
+          a.stepTimer <= 0 ||
+          (a.combo.guardedHits > 0 && (!this.meleeOnly || a.hasBlockEntity()))
+        ) {
+          a.combo.guardTrapTime = 0;
+          return true;
         }
-      }
-    }),
-    init: function (a) {
-      this.maxTime = a.maxTime;
-      this.meleeOnly = a.meleeOnly || false
-    },
-    start: function (a) {
-      a.stepTimer = a.stepTimer + this.maxTime
-    },
-    run: function (a) {
-      a = a.getCombatantRoot();
-      if (a.isPlayer)
-        if (ig.input.currentDevice == ig.INPUT_DEVICES.KEYBOARD_AND_MOUSE) a.gui.crosshair.getDir(a.face);
-        else {
-          sc.control.moveDir(r, 1);
-          Vec2.isZero(r) || Vec2.assign(a.face, r)
-        } a.combo.guardTrapTime = a.combo.guardTrapTime + ig.system.tick;
-      if (a.stepTimer <= 0 || a.combo.guardedHits > 0 &&
-        (!this.meleeOnly || a.hasBlockEntity())) {
-        a.combo.guardTrapTime = 0;
-        return true
-      }
-      return false
-    }
-  });
-*/
-/*
+        return false;
+      },
+    });
+
+    /*
   //Needed to add the "add" functionality for the Curse of Vanishing combat art.
   //Edit: this does not work at all.
   var C = {
@@ -126,4 +116,4 @@ ig.module("game.feature.combat.hex-combat-action-steps").requires("game.feature.
     }
   });
 */
-});
+  });


### PR DESCRIPTION
Copies `WAIT_UNTIL_GUARDED` and removes the relevant block that automatically turns the player.
